### PR TITLE
Fix: Create user_auth record on first login for new Keycloak users

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -72,6 +72,27 @@ class Events
             return;
         }
 
+        // Recover Auth record for newly registered Keycloak users.
+        // On a user's very first login, Keycloak::syncUserAttributes() runs
+        // before the user has been persisted in the database, so the Auth
+        // record cannot be written at that point. EVENT_AFTER_LOGIN fires
+        // after the user has been persisted, so we can catch up here.
+        // Without this, user_auth.source_id stays empty until the user
+        // logs in a second time, which in turn prevents the group sync
+        // (both GroupsUserSync and GroupsFullSync rely on this record).
+        if ($user->auth_mode === Keycloak::DEFAULT_NAME) {
+            $existingAuth = Auth::findOne([
+                'user_id' => $user->id,
+                'source' => Keycloak::DEFAULT_NAME,
+            ]);
+            if ($existingAuth === null) {
+                $authClient = Yii::$app->authClientCollection->getClient(Keycloak::DEFAULT_NAME);
+                if ($authClient instanceof Keycloak) {
+                    $authClient->createOrUpdateAuthRecord($user);
+                }
+            }
+        }
+
         if ($config->updatedBrokerUsernameFromHumhubUsername) {
             Yii::$app->queue->push(new UpdateUserUsername(['userId' => $user->id]));
         }

--- a/authclient/Keycloak.php
+++ b/authclient/Keycloak.php
@@ -124,6 +124,58 @@ class Keycloak extends OpenIdConnect implements PrimaryClient
     }
 
     /**
+     * Creates or updates the Keycloak Auth record for a given user.
+     *
+     * Extracted from syncUserAttributes() so the same logic can be called
+     * from Events::onAfterLogin() as well. This is needed to recover the
+     * Auth record for newly registered users: syncUserAttributes() runs
+     * during OAuth callback processing, but at that point a brand-new user
+     * does not yet exist in the database, so getUser() returns null and
+     * the original logic exits before the Auth record can be written.
+     * EVENT_AFTER_LOGIN fires after the user has been persisted, so calling
+     * this method from there guarantees the Auth record is created on the
+     * very first login.
+     *
+     * @param User $user
+     * @return void
+     */
+    public function createOrUpdateAuthRecord(User $user)
+    {
+        $userAttributes = $this->getUserAttributes();
+        $sourceId = $userAttributes['id'] ?? null;
+        if (!$sourceId) {
+            return;
+        }
+
+        $auth = AuthKeycloak::findOne([
+            'source' => self::DEFAULT_NAME,
+            'source_id' => $sourceId,
+        ]);
+
+        // Make sure authClient is not doubly assigned
+        if ($auth !== null && $auth->user_id !== $user->id) {
+            $auth->delete();
+            $auth = null;
+        }
+
+        // Get Keycloak shared session identifier
+        $sid = Yii::$app->request->get('session_state');
+
+        if ($auth === null) {
+            $auth = new AuthKeycloak([
+                'user_id' => $user->id,
+                'source' => self::DEFAULT_NAME,
+                'source_id' => (string)$sourceId,
+                'keycloak_sid' => $sid,
+            ]);
+            $auth->save();
+        } elseif ($auth->keycloak_sid !== $sid) {
+            $auth->keycloak_sid = $sid;
+            $auth->save();
+        }
+    }
+
+    /**
      * @inheridoc
      * @throws StaleObjectException
      * @throws \Throwable
@@ -142,35 +194,7 @@ class Keycloak extends OpenIdConnect implements PrimaryClient
         } catch (PDOException) {
         }
 
-        $sourceId = $userAttributes['id'] ?? null;
-        if ($sourceId) {
-            $auth = AuthKeycloak::findOne([
-                'source' => self::DEFAULT_NAME,
-                'source_id' => $sourceId,
-            ]);
-
-            // Make sure authClient is not doubly assigned
-            if ($auth !== null && $auth->user_id !== $user->id) {
-                $auth->delete();
-                $auth = null;
-            }
-
-            // Get Keycloak shared session identifier
-            $sid = Yii::$app->request->get('session_state');
-
-            if ($auth === null) {
-                $auth = new AuthKeycloak([
-                    'user_id' => $user->id,
-                    'source' => self::DEFAULT_NAME,
-                    'source_id' => (string)$sourceId,
-                    'keycloak_sid' => $sid,
-                ]);
-                $auth->save();
-            } elseif ($auth->keycloak_sid !== $sid) {
-                $auth->keycloak_sid = $sid;
-                $auth->save();
-            }
-        }
+        $this->createOrUpdateAuthRecord($user);
 
         /** @var Module $module */
         $module = Yii::$app->getModule('auth-keycloak');


### PR DESCRIPTION
## Context

I run a HumHub instance for students at our university, with Keycloak as the single source of truth for identities and group memberships. New students get accounts in Keycloak and are assigned to the corresponding course group there; the first time they visit HumHub, they sign in via the Keycloak button and should automatically end up in the matching HumHub group.

In practice, this worked reliably for only some users. New students kept landing in the default "Users" group only, and even the daily `GroupsFullSync` cron didn't pick them up - sometimes for days, until they happened to log in again. Debugging showed that their `user_auth` row was missing the Keycloak `source_id`, which caused every sync path to ignore them. Once they logged in a second time, the Auth record was written, and the next sync picked them up.

## Problem

When a user logs in via Keycloak for the very first time (no pre-existing HumHub account), the `user_auth` record for that user is not written. This causes group synchronization to silently fail for the user, as both `GroupsUserSync` and `GroupsFullSync` rely on `user_auth.source_id` being set to the Keycloak UUID.

The user only ends up in their correct HumHub groups after their **second** login - at which point `getUser()` finds them via email, and the original logic then writes the Auth record.

## Root cause

`Keycloak::syncUserAttributes()` is called via `getUserAttributes()` during OAuth callback processing. It uses `getUser()` to locate the target HumHub user and bails out early if that returns `null`:

```php
public function syncUserAttributes()
{
    $user = $this->getUser();
    if ($user === null) {
        return;  // <-- early exit for new users
    }
    // ... Auth record creation would happen here
}
```

For brand-new users, the HumHub user doesn't exist yet at this point - HumHub's core `AuthController` creates it *after* reading the attributes. So `getUser()` returns `null`, the method exits, and no Auth record is ever written.

## Fix

Extract the Auth-record persistence logic from `syncUserAttributes()` into a new public method `createOrUpdateAuthRecord(User $user)` on the authclient, and call it additionally from `Events::onAfterLogin()` when a Keycloak user is detected without an existing Auth record.

`EVENT_AFTER_LOGIN` fires *after* the user has been persisted in the database, so the Auth record can be created reliably on the first login. For existing users, nothing changes - `syncUserAttributes()` still writes the record during the OAuth callback, and the additional check in `onAfterLogin()` is a no-op because the record already exists.

## Reproduction

1. Create a new user in Keycloak who doesn't exist in HumHub
2. Assign that user to a Keycloak group that is synced with a HumHub group
3. Log into HumHub via Keycloak for the first time
4. Expected: User is in the synced HumHub group
5. Actual (before this fix): User is only in the default "Users" group; `user_auth` row is missing

## Testing

Tested on HumHub 1.17 with Keycloak 26 against a production instance with ~300 users. Verified that:

- New users now get the `user_auth.source_id` populated on first login
- Existing users with a properly-populated `user_auth` record are unaffected
- Users whose Auth record was missing from a previous first login also get it recovered the next time they log in

## Related changelog entry

The changelog for v1.2.2 already mentions a related fix ("For some users, the corresponding user ID on Keycloak was not saved in user_auth table"). This PR addresses a specific remaining case: a brand-new user registering through the OAuth flow.

## Open question / potential follow-up

With this fix the Auth record is created on the first login, but the group membership itself is only applied once the `GroupsUserSync` job from the queue runs. In my testing, `GroupsUserSync` didn't actually assign the new user to their Keycloak group in every case - only the subsequent `GroupsFullSync` (via the daily cron) did. I haven't dug into why yet and didn't want to expand the scope of this PR, but it might be worth considering whether `Events::onAfterLogin()` should additionally push a `GroupsFullSync` (or run the user-level sync more reliably) so that new users land in their groups on first login rather than having to wait up to 24 hours for the daily cron.