### PR TITLE
Compatibility with HumHub 1.19 user/auth refactor

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -20,6 +20,7 @@ use humhub\modules\authKeycloak\jobs\GroupsUserSync;
 use humhub\modules\authKeycloak\jobs\UpdateUserEmail;
 use humhub\modules\authKeycloak\jobs\UpdateUserUsername;
 use humhub\modules\authKeycloak\models\ConfigureForm;
+use humhub\modules\authKeycloak\source\KeycloakUserSource;
 use humhub\modules\ui\menu\MenuLink;
 use humhub\modules\user\authclient\Collection;
 use humhub\modules\user\events\UserEvent;
@@ -37,6 +38,24 @@ use yii\helpers\Console;
 
 class Events
 {
+    /**
+     * Registers the Keycloak UserSource. Opt-out via `Module::$provideUserSource = false`.
+     *
+     * @param Event $event UserSourceCollection::EVENT_BEFORE_USER_SOURCES_SET
+     */
+    public static function onUserSourceCollectionSet($event)
+    {
+        /** @var Module $module */
+        $module = Yii::$app->getModule('auth-keycloak');
+        if (!$module || !$module->provideUserSource) {
+            return;
+        }
+
+        $event->parameters['userSources'][KeycloakUserSource::SOURCE_ID] = [
+            'class' => KeycloakUserSource::class,
+        ];
+    }
+
     /**
      * @param Event $event
      * @return void
@@ -80,16 +99,17 @@ class Events
         // Without this, user_auth.source_id stays empty until the user
         // logs in a second time, which in turn prevents the group sync
         // (both GroupsUserSync and GroupsFullSync rely on this record).
-        if ($user->auth_mode === Keycloak::DEFAULT_NAME) {
-            $existingAuth = Auth::findOne([
-                'user_id' => $user->id,
-                'source' => Keycloak::DEFAULT_NAME,
-            ]);
-            if ($existingAuth === null) {
-                $authClient = Yii::$app->authClientCollection->getClient(Keycloak::DEFAULT_NAME);
-                if ($authClient instanceof Keycloak) {
-                    $authClient->createOrUpdateAuthRecord($user);
-                }
+        // For non-Keycloak logins the Keycloak auth client has no user
+        // attributes in the session, so createOrUpdateAuthRecord() exits
+        // early.
+        $existingAuth = Auth::findOne([
+            'user_id' => $user->id,
+            'source' => Keycloak::DEFAULT_NAME,
+        ]);
+        if ($existingAuth === null) {
+            $authClient = Yii::$app->authClientCollection->getClient(Keycloak::DEFAULT_NAME);
+            if ($authClient instanceof Keycloak) {
+                $authClient->createOrUpdateAuthRecord($user);
             }
         }
 

--- a/Module.php
+++ b/Module.php
@@ -25,6 +25,22 @@ class Module extends BaseModule
     public $apiVerifySsl = true;
 
     /**
+     * @var bool Register a dedicated UserSource for Keycloak-provisioned users.
+     *
+     * Default: true. Mirrors the pre-1.19 `PrimaryClient` semantic — users that
+     * log in via Keycloak are owned by this module (locked profile attributes
+     * per the `updateHumhubEmailFromBrokerEmail` / `updateHumhubUsernameFromBrokerUsername`
+     * settings, password tab hidden, etc.).
+     *
+     * Set to false in `protected/config/common.php` to opt out — Keycloak users
+     * then fall back to `LocalUserSource`. See `docs/CHANGELOG.md` 1.6.0 for the
+     * trade-offs.
+     *
+     * @since 1.6.0
+     */
+    public bool $provideUserSource = true;
+
+    /**
      * @inheritdoc
      */
     public function getConfigUrl()

--- a/authclient/Keycloak.php
+++ b/authclient/Keycloak.php
@@ -12,7 +12,6 @@ namespace humhub\modules\authKeycloak\authclient;
 use humhub\modules\authKeycloak\models\AuthKeycloak;
 use humhub\modules\authKeycloak\models\ConfigureForm;
 use humhub\modules\authKeycloak\Module;
-use humhub\modules\user\authclient\interfaces\PrimaryClient;
 use humhub\modules\user\models\Auth;
 use humhub\modules\user\models\User;
 use humhub\modules\user\services\AuthClientUserService;
@@ -24,11 +23,7 @@ use yii\base\InvalidConfigException;
 use yii\db\StaleObjectException;
 use yii\helpers\BaseInflector;
 
-/**
- * With PrimaryClient, the user will have the `auth_mode` field in the `user` table set to 'Keycloak'.
- * This will avoid showing the "Change Password" tab when logged in with Keycloak
- */
-class Keycloak extends OpenIdConnect implements PrimaryClient
+class Keycloak extends OpenIdConnect
 {
     public const DEFAULT_NAME = 'Keycloak';
 

--- a/components/KeycloakApi.php
+++ b/components/KeycloakApi.php
@@ -16,7 +16,6 @@ use humhub\modules\authKeycloak\models\ConfigureForm;
 use humhub\modules\authKeycloak\models\GroupKeycloak;
 use humhub\modules\authKeycloak\Module;
 use humhub\modules\user\models\Auth;
-use humhub\modules\user\models\User;
 use Keycloak\Admin\KeycloakClient;
 use Yii;
 use yii\base\Component;
@@ -114,22 +113,10 @@ class KeycloakApi extends Component
      */
     public function getUserAuth($userId)
     {
-        $auth = Auth::find()
+        return Auth::find()
             ->where(['source' => Keycloak::DEFAULT_NAME, 'user_id' => $userId])
             ->orderBy(['id' => SORT_DESC]) // get the latest if it has multiple
             ->one();
-
-        if ($auth === null) {
-            $user = User::findOne(['id' => $userId, 'auth_mode' => Keycloak::DEFAULT_NAME]);
-            if ($user !== null) {
-                $keycloakUserId = $this->getUserId($user->email);
-                if ($keycloakUserId !== null) {
-                    $auth = Auth::findOne(['source' => Keycloak::DEFAULT_NAME, 'source_id' => $keycloakUserId]);
-                }
-            }
-        }
-
-        return $auth;
     }
 
     /**

--- a/config.php
+++ b/config.php
@@ -16,6 +16,7 @@ use humhub\modules\user\models\Auth;
 use humhub\modules\user\models\Group;
 use humhub\modules\user\models\GroupUser;
 use humhub\modules\user\models\User;
+use humhub\modules\user\source\UserSourceCollection;
 use humhub\modules\user\widgets\AccountProfileMenu;
 use yii\web\User as UserComponent;
 
@@ -109,6 +110,11 @@ return [
             'class' => AccountProfileMenu::class,
             'event' => AccountProfileMenu::EVENT_INIT,
             'callback' => [Events::class, 'onAccountProfileMenuInit'],
+        ],
+        [
+            'class' => UserSourceCollection::class,
+            'event' => UserSourceCollection::EVENT_BEFORE_USER_SOURCES_SET,
+            'callback' => [Events::class, 'onUserSourceCollectionSet'],
         ],
     ],
 ];

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.6.0 (Unreleased)
+--------------------
+- Enh: Compatibility with HumHub 1.19 user/auth refactor (humhub/humhub#TBD)
+- Enh: Register `KeycloakUserSource` — Keycloak users are now properly owned by this module (`user.user_source = 'Keycloak'`), replacing the pre-1.19 `PrimaryClient` semantic. Locked profile attributes follow the existing `updateHumhubEmailFromBrokerEmail` / `updateHumhubUsernameFromBrokerUsername` settings. Opt out via `Module::$provideUserSource = false`.
+- Enh: One-time migration backfills `user_source = 'Keycloak'` for every existing user with a Keycloak `user_auth` row (core's 1.19 migration only backfills LDAP).
+- Chg: Drop `PrimaryClient` marker on `Keycloak` auth client (interface is now an empty marker in core)
+- Chg: Drop legacy `user.auth_mode` lookups — the column is removed in core 1.19. Auth record recovery on first login now relies solely on the missing `user_auth` row + the current OAuth session.
+- Chg: Minimum HumHub version is now 1.19
+
 1.5.3 (May 6, 2026)
 --------------------
 - Fix #32: Error with account reconciliation when same email

--- a/migrations/m260515_120000_backfill_user_source.php
+++ b/migrations/m260515_120000_backfill_user_source.php
@@ -1,0 +1,42 @@
+<?php
+
+use humhub\components\Migration;
+use humhub\modules\authKeycloak\authclient\Keycloak;
+
+/**
+ * Claims existing Keycloak users for the new `KeycloakUserSource`.
+ *
+ * Before HumHub 1.19, Keycloak users were identified by `user.auth_mode = 'Keycloak'`.
+ * Core's 1.19 migration drops the `auth_mode` column and resets every user to
+ * `user_source = 'local'`. This migration walks the (already-populated)
+ * `user_auth` table and reclaims any user with a Keycloak auth row, so the
+ * UserSource registered by this module owns them on first login post-upgrade.
+ */
+class m260515_120000_backfill_user_source extends Migration
+{
+    public function safeUp()
+    {
+        $this->execute(
+            'UPDATE {{%user}} u'
+            . ' INNER JOIN {{%user_auth}} ua ON ua.user_id = u.id'
+            . ' SET u.user_source = :source'
+            . ' WHERE ua.source = :source'
+            . '   AND u.user_source = :local',
+            [
+                ':source' => Keycloak::DEFAULT_NAME,
+                ':local' => 'local',
+            ],
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->execute(
+            'UPDATE {{%user}} SET user_source = :local WHERE user_source = :source',
+            [
+                ':source' => Keycloak::DEFAULT_NAME,
+                ':local' => 'local',
+            ],
+        );
+    }
+}

--- a/module.json
+++ b/module.json
@@ -6,10 +6,9 @@
         "auth",
         "keycloak"
     ],
-    "version": "1.5.3",
+    "version": "1.6.0",
     "humhub": {
-        "minVersion": "1.18",
-        "maxVersion": "1.18"
+        "minVersion": "1.19"
     },
     "homepage": "https://github.com/cuzy-app/auth-keycloak",
     "authors": [

--- a/source/KeycloakUserSource.php
+++ b/source/KeycloakUserSource.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Keycloak Sign-In
+ * @link https://github.com/cuzy-app/auth-keycloak
+ * @license https://github.com/cuzy-app/auth-keycloak/blob/master/docs/LICENCE.md
+ * @author [Marc FARRE](https://marc.fun) for [CUZY.APP](https://www.cuzy.app)
+ */
+
+namespace humhub\modules\authKeycloak\source;
+
+use humhub\modules\authKeycloak\authclient\Keycloak;
+use humhub\modules\authKeycloak\Module;
+use humhub\modules\user\models\forms\Registration;
+use humhub\modules\user\models\User;
+use humhub\modules\user\source\BaseUserSource;
+use humhub\modules\user\source\UserSourceInterface;
+use Yii;
+use yii\helpers\VarDumper;
+
+/**
+ * KeycloakUserSource owns users provisioned through the Keycloak auth client.
+ *
+ * Replaces the pre-1.19 `PrimaryClient` marker that set `user.auth_mode = 'Keycloak'`.
+ * Registered by {@see \humhub\modules\authKeycloak\Events::onUserSourceCollectionSet()}
+ * when {@see Module::$provideUserSource} is enabled (default: true).
+ *
+ * @since 1.6.0
+ */
+class KeycloakUserSource extends BaseUserSource
+{
+    public const SOURCE_ID = Keycloak::DEFAULT_NAME;
+
+    public function init()
+    {
+        parent::init();
+
+        if ($this->id === '') {
+            $this->id = self::SOURCE_ID;
+        }
+        if ($this->allowedAuthClientIds === []) {
+            $this->allowedAuthClientIds = [self::SOURCE_ID];
+        }
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title !== '' ? $this->title : 'Keycloak';
+    }
+
+    /**
+     * Managed attributes are derived from the existing module settings so
+     * pre-1.19 sync configuration is preserved verbatim:
+     *  - `updateHumhubEmailFromBrokerEmail`    → `email` is locked & synced
+     *  - `updateHumhubUsernameFromBrokerUsername` → `username` is locked & synced
+     *
+     * Admins who previously disabled auto-sync keep the same behaviour and
+     * the affected fields stay editable in the admin UI.
+     */
+    public function getManagedAttributes(): array
+    {
+        $module = $this->getKeycloakModule();
+        if ($module === null) {
+            return [];
+        }
+
+        $attrs = [];
+        if ((bool) $module->settings->get('updateHumhubEmailFromBrokerEmail')) {
+            $attrs[] = 'email';
+        }
+        if ((bool) $module->settings->get('updateHumhubUsernameFromBrokerUsername')) {
+            $attrs[] = 'username';
+        }
+
+        return $attrs;
+    }
+
+    public function requiresApproval(?string $authClientId = null): bool
+    {
+        if ($authClientId !== null && in_array($authClientId, $this->trustedAuthClientIds, true)) {
+            return false;
+        }
+
+        /** @var \humhub\modules\user\Module $userModule */
+        $userModule = Yii::$app->getModule('user');
+        return (bool) $userModule->settings->get('auth.needApproval');
+    }
+
+    public function getUsernameStrategy(): string
+    {
+        return UserSourceInterface::USERNAME_AUTO_GENERATE;
+    }
+
+    /**
+     * Creates a HumHub user with `user_source = 'Keycloak'`.
+     *
+     * Note: the user_auth row is written by the auth client's
+     * {@see Keycloak::createOrUpdateAuthRecord()} (which also stores
+     * `keycloak_sid`). It is NOT created here.
+     */
+    public function createUser(array $attributes): ?User
+    {
+        $registration = $this->buildRegistration($attributes);
+        if ($registration === null) {
+            return null;
+        }
+
+        $registration->getUser()->user_source = $this->getId();
+
+        if (!$registration->register()) {
+            Yii::warning(
+                'KeycloakUserSource: could not create user. Errors: '
+                . VarDumper::dumpAsString($registration->getErrors()),
+                'auth-keycloak',
+            );
+            return null;
+        }
+
+        return $registration->getUser();
+    }
+
+    private function buildRegistration(array $attributes): ?Registration
+    {
+        $registration = new Registration(enableEmailField: true, enablePasswordForm: false);
+        $registration->enableUserApproval = $this->requiresApproval(self::SOURCE_ID);
+
+        unset(
+            $attributes['id'],
+            $attributes['guid'],
+            $attributes['contentcontainer_id'],
+            $attributes['user_source'],
+            $attributes['status'],
+        );
+
+        $registration->getUser()->setAttributes($attributes, false);
+        $registration->getProfile()->setAttributes($attributes, false);
+        $registration->getGroupUser()->setAttributes($attributes, false);
+        $registration->setModels();
+
+        return $registration;
+    }
+
+    private function getKeycloakModule(): ?Module
+    {
+        /** @var Module|null $module */
+        $module = Yii::$app->getModule('auth-keycloak');
+        return $module;
+    }
+}


### PR DESCRIPTION
## Summary

Adapts the module to the HumHub 1.19 user/auth refactor (humhub/humhub user-source line — replaces the legacy `user.auth_mode` + `authclient_id` columns with `user.user_source` plus the `user_auth` table).

### Source-level integration
- **New `KeycloakUserSource`** (`source/KeycloakUserSource.php`) — Keycloak-provisioned users are now properly owned by this module (`user.user_source = 'Keycloak'`), replacing the pre-1.19 `PrimaryClient` marker that wrote `user.auth_mode = 'Keycloak'`.
- `managedAttributes` (= profile fields locked in the admin UI + auto-synced on login) is derived from the existing module settings:
  - `updateHumhubEmailFromBrokerEmail` → `email` is managed
  - `updateHumhubUsernameFromBrokerUsername` → `username` is managed

  So admins who previously disabled auto-sync keep the same behaviour and those fields stay editable.
- New `Module::$provideUserSource` (default **true**) lets admins opt out via `protected/config/common.php` — Keycloak users then fall back to `LocalUserSource`.

### Data migration
- `migrations/m260515_120000_backfill_user_source.php` claims existing Keycloak users:
  ```sql
  UPDATE user u
  INNER JOIN user_auth ua ON ua.user_id = u.id
  SET u.user_source = 'Keycloak'
  WHERE ua.source = 'Keycloak' AND u.user_source = 'local';
  ```
  Required because core's 1.19 migration only backfills `user_source` for LDAP — every other auth-owning module has to claim its own users.

### Compat cleanup
- `authclient/Keycloak.php` — drop `implements PrimaryClient` (the interface is now an empty marker in core; semantics moved to `UserSource`).
- `Events.php::onAfterLogin()` — drop the `$user->auth_mode === Keycloak::DEFAULT_NAME` gate; the column is gone in 1.19. Recovery now runs unconditionally and is a no-op for non-Keycloak logins (`Keycloak::createOrUpdateAuthRecord()` exits early when there is no OAuth session).
- `components/KeycloakApi::getUserAuth()` — drop the `User::findOne(['auth_mode' => ...])` fallback for the same reason. Since #33 was merged the `user_auth` row is reliably written on first login, so the fallback is dead code.

### Other
- `module.json`: `version` 1.5.3 → 1.6.0, `humhub.minVersion` 1.18 → 1.19, drop `maxVersion`.
- `docs/CHANGELOG.md`: new 1.6.0 (Unreleased) section.

## Compatibility

- **Breaking**: requires HumHub 1.19+.
- **Existing Keycloak users**: migrated automatically to `user_source = 'Keycloak'` (see migration above). Users without a `user_auth` Keycloak row (pre-1.5.2 installs that never had a second login) stay on `user_source = 'local'` and behave as a local user until they log in via Keycloak — at which point the recovery in `onAfterLogin()` creates the `user_auth` row; their `user_source` then remains `local` unless the admin runs the migration again. In practice this only affects very old installs; for fresh 1.5.2+ data the backfill is complete.
- **Behaviour preserved**: email/username auto-sync still respects the existing module settings.
- **Behaviour changed**: profile fields managed by Keycloak are now locked in the admin UI (previously editable).

## Test plan

- [ ] Fresh install on HumHub 1.19 + Keycloak → user registers via Keycloak → `user.user_source = 'Keycloak'`, `user_auth` row present.
- [ ] Upgrade from 1.5.3 → run migration → existing Keycloak users have `user_source = 'Keycloak'`.
- [ ] Toggle `updateHumhubEmailFromBrokerEmail` off → email field unlocked in admin UI, not auto-synced on login.
- [ ] Set `provideUserSource = false` in `common.php` → fresh Keycloak login → user lands in `LocalUserSource` (no UI locking, free sync via the auth client's own `syncUserAttributes()`).
- [ ] Group sync still functional after upgrade (depends on `user_auth.source_id`, unchanged).